### PR TITLE
Add landing page, login, and billing link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+.env.local

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -14,12 +14,15 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <header className="bg-white border-b">
         <div className="container py-4 flex items-center gap-4">
           <Link href="/" className="text-xl font-semibold">BackdoorDox</Link>
-          <nav className="flex items-center gap-2">
+          <nav className="flex items-center gap-2 flex-1">
+            <Tab href="/dashboard">Dashboard</Tab>
             <Tab href="/watermark">Watermark</Tab>
             <Tab href="/activity">Activity</Tab>
             <Tab href="/api">API</Tab>
+            <Tab href="/payment">Payment</Tab>
           </nav>
-          <div className="ml-auto text-sm text-gray-500">MVP</div>
+          <Link href="/login" className="btn btn-outline">Login</Link>
+          <div className="text-sm text-gray-500">MVP</div>
         </div>
       </header>
       <main className="container py-8 space-y-6">{children}</main>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,35 @@
+
+import Layout from '../components/Layout'
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <Layout>
+      <div className="card">
+        <h1 className="text-3xl font-bold mb-2">Welcome back!</h1>
+        <p className="text-gray-600">Protect your MCA files from backdooring with watermarking and tracked, read-only links.</p>
+        <div className="mt-6 flex gap-3">
+          <Link href="/watermark" className="btn btn-primary">Watermark</Link>
+          <Link href="/activity" className="btn btn-outline">File Tracker</Link>
+        </div>
+      </div>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="card">
+          <div className="badge mb-2">Feature</div>
+          <h3 className="font-semibold">OCR-safe overlay</h3>
+          <p className="hint">Page render stays vector (no rasterization). Watermark text is thin + low opacity to minimize OCR interference.</p>
+        </div>
+        <div className="card">
+          <div className="badge mb-2">Feature</div>
+          <h3 className="font-semibold">Read-only links</h3>
+          <p className="hint">Gate by business email and log each access (IP, UA, fingerprint). Detect unusual access patterns.</p>
+        </div>
+        <div className="card">
+          <div className="badge mb-2">Feature</div>
+          <h3 className="font-semibold">Flags & Signals</h3>
+          <p className="hint">We surface geo/IP shifts, rapid link sharing, and odd device changes so you can respond quickly.</p>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,33 +1,28 @@
-
 import Layout from '../components/Layout'
 import Link from 'next/link'
 
-export default function Home() {
+export default function Landing() {
   return (
     <Layout>
-      <div className="card">
-        <h1 className="text-3xl font-bold mb-2">Welcome back!</h1>
-        <p className="text-gray-600">Protect your MCA files from backdooring with watermarking and tracked, read-only links.</p>
-        <div className="mt-6 flex gap-3">
-          <Link href="/watermark" className="btn btn-primary">Watermark</Link>
-          <Link href="/activity" className="btn btn-outline">File Tracker</Link>
-        </div>
-      </div>
-      <div className="grid md:grid-cols-3 gap-4">
+      <section className="text-center max-w-3xl mx-auto">
+        <h1 className="text-4xl font-bold mb-4">Stop Backdooring With Document Watermarks</h1>
+        <p className="text-gray-600 mb-6">
+          BackdoorDox helps merchant cash advance ISOs protect deal files by stamping every page and tracking every view.
+        </p>
+        <Link href="/login" className="btn btn-primary">Log in or Sign up</Link>
+      </section>
+      <div className="grid md:grid-cols-3 gap-4 mt-10">
         <div className="card">
-          <div className="badge mb-2">Feature</div>
-          <h3 className="font-semibold">OCR-safe overlay</h3>
-          <p className="hint">Page render stays vector (no rasterization). Watermark text is thin + low opacity to minimize OCR interference.</p>
+          <h3 className="font-semibold mb-2">Persistent watermarks</h3>
+          <p className="hint">Overlay ISO, broker and timestamp details so leaks are traceable.</p>
         </div>
         <div className="card">
-          <div className="badge mb-2">Feature</div>
-          <h3 className="font-semibold">Read-only links</h3>
-          <p className="hint">Gate by business email and log each access (IP, UA, fingerprint). Detect unusual access patterns.</p>
+          <h3 className="font-semibold mb-2">Access tracking</h3>
+          <p className="hint">Read-only links log IP, device and geography for every view.</p>
         </div>
         <div className="card">
-          <div className="badge mb-2">Feature</div>
-          <h3 className="font-semibold">Flags & Signals</h3>
-          <p className="hint">We surface geo/IP shifts, rapid link sharing, and odd device changes so you can respond quickly.</p>
+          <h3 className="font-semibold mb-2">Simple sharing</h3>
+          <p className="hint">Distribute funding files confidently from a single dashboard.</p>
         </div>
       </div>
     </Layout>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import Layout from '../components/Layout'
+
+export default function Login() {
+  const router = useRouter()
+  const [mode, setMode] = useState<'login' | 'signup'>('login')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    router.push('/dashboard')
+  }
+
+  return (
+    <Layout>
+      <div className="max-w-sm mx-auto card">
+        <div className="flex justify-center gap-2 mb-4">
+          <button onClick={() => setMode('login')} className={`btn ${mode==='login' ? 'btn-primary' : 'btn-outline'}`}>Log in</button>
+          <button onClick={() => setMode('signup')} className={`btn ${mode==='signup' ? 'btn-primary' : 'btn-outline'}`}>Sign up</button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input type="email" required placeholder="Email" className="input w-full" />
+          <input type="password" required placeholder="Password" className="input w-full" />
+          <button type="submit" className="btn btn-primary w-full">{mode==='login' ? 'Log in' : 'Create account'}</button>
+        </form>
+      </div>
+    </Layout>
+  )
+}

--- a/pages/payment.tsx
+++ b/pages/payment.tsx
@@ -1,0 +1,14 @@
+import Layout from '../components/Layout'
+
+export default function Payment() {
+  const checkout = process.env.NEXT_PUBLIC_STRIPE_CHECKOUT_URL || '#'
+  return (
+    <Layout>
+      <div className="card max-w-md mx-auto text-center">
+        <h1 className="text-2xl font-bold mb-2">Billing</h1>
+        <p className="hint mb-4">Manage your subscription through Stripe.</p>
+        <a href={checkout} className="btn btn-primary">Go to payment</a>
+      </div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace home page with public marketing landing page and move existing app into a dashboard
- Add simple login/sign‑up page and navigation link
- Include Stripe checkout link for billing and expose dashboard and features in navigation

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f664277083328ab1686b94a6c1ca