### PR TITLE
Enable public landing page, email confirmation, and secure link generation

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,13 +1,27 @@
 
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { pathname } = useRouter()
-  const Tab = ({ href, children }: { href: string, children: React.ReactNode }) => (
-    <Link href={href} className={`btn ${pathname===href ? 'bg-gray-900 text-white' : 'btn-outline'} `}>{children}</Link>
+  const [user, setUser] = useState<{ email: string } | null>(null)
+
+  useEffect(() => {
+    fetch('/api/me')
+      .then(r => (r.ok ? r.json() : null))
+      .then(setUser)
+      .catch(() => setUser(null))
+  }, [])
+
+  const Tab = ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <Link href={href} className={`btn ${pathname === href ? 'bg-gray-900 text-white' : 'btn-outline'} `}>{children}</Link>
   )
+
+  const logout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST' })
+    window.location.href = '/'
+  }
 
   return (
     <div>
@@ -15,15 +29,24 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <div className="container py-4 flex items-center gap-4">
           <Link href="/" className="text-xl font-semibold">BackdoorDox</Link>
           <nav className="flex items-center gap-2 flex-1">
-            <Tab href="/dashboard">Dashboard</Tab>
-            <Tab href="/watermark">Watermark</Tab>
-            <Tab href="/activity">Activity</Tab>
-            <Tab href="/api">API</Tab>
-            <Tab href="/payment">Payment</Tab>
+            {user ? (
+              <>
+                <Tab href="/dashboard">Dashboard</Tab>
+                <Tab href="/watermark">Watermark</Tab>
+                <Tab href="/activity">Activity</Tab>
+                <Tab href="/api">API</Tab>
+                <Tab href="/payment">Payment</Tab>
+              </>
+            ) : (
+              <Tab href="/">Home</Tab>
+            )}
           </nav>
           <div className="flex items-center gap-2">
-            <Link href="/login" className="btn btn-outline">Login</Link>
-            <Link href="/login?mode=signup" className="btn btn-primary">Sign up</Link>
+            {user ? (
+              <button onClick={logout} className="btn btn-outline">Logout</button>
+            ) : (
+              <Link href="/login" className="btn btn-outline">Login</Link>
+            )}
           </div>
           <div className="text-sm text-gray-500">MVP</div>
         </div>

--- a/pages/api/auth/confirm.ts
+++ b/pages/api/auth/confirm.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { kv } from '@vercel/kv'
+import { requireEnv } from '../../../lib/env'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end()
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
+  const token = req.query.token as string
+  if (!token) return res.status(400).end('token required')
+  const email = await kv.get<string>(`confirm:${token}`)
+  if (!email) {
+    res.status(400).end('Invalid or expired token')
+    return
+  }
+  await kv.hset(`user:${email}`, { confirmedAt: new Date().toISOString() } as any)
+  await kv.del(`confirm:${token}`)
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
+  res.end('<p>Email confirmed. You can now <a href="/login">log in</a>.</p>')
+}

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -10,9 +10,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN', 'JWT_SECRET'])) return
   const { email, password } = req.body
   const user = await authenticate(email, password)
-  if (user) {
+  if (user && user.confirmedAt) {
     createSession(res, user)
     res.status(200).json({ ok: true })
+  } else if (user && !user.confirmedAt) {
+    res.status(403).json({ error: 'Please confirm your email' })
   } else {
     res.status(401).json({ error: 'Invalid credentials' })
   }

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  res.setHeader('Set-Cookie', 'bdx_session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0')
+  res.status(200).json({ ok: true })
+}

--- a/pages/api/auth/resend-confirmation.ts
+++ b/pages/api/auth/resend-confirmation.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { kv } from '@vercel/kv'
+import { requireEnv } from '../../../lib/env'
+import { getUser, sendConfirmationEmail } from '../../../lib/auth'
+import crypto from 'crypto'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
+  const { email } = req.body || {}
+  if (!email) return res.status(200).json({ ok: true })
+  const ip = (req.headers['x-forwarded-for'] as string || '').split(',')[0] || req.socket.remoteAddress || 'unknown'
+  const key = `resend:${ip}:${email}`
+  const count = await kv.incr(key)
+  if (count === 1) await kv.expire(key, 3600)
+  if (count > 3) return res.status(429).json({ error: 'Too many requests' })
+  const user = await getUser(email)
+  if (user && !user.confirmedAt) {
+    const token = crypto.randomBytes(32).toString('hex')
+    await kv.set(`confirm:${token}`, user.email, { ex: 60 * 60 * 24 })
+    await sendConfirmationEmail(user.email, token)
+  }
+  res.status(200).json({ ok: true })
+}

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { registerUser, createSession } from '../../../lib/auth'
+import { registerUser } from '../../../lib/auth'
 import { requireEnv } from '../../../lib/env'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -7,11 +7,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(405).end()
     return
   }
-  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN', 'JWT_SECRET'])) return
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
   const { email, password } = req.body
   try {
-    const user = await registerUser(email, password)
-    createSession(res, user)
+    await registerUser(email, password)
     res.status(200).json({ ok: true })
   } catch (err: any) {
     res.status(400).json({ error: err.message || 'error' })

--- a/pages/api/get-link.ts
+++ b/pages/api/get-link.ts
@@ -9,5 +9,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!id) return res.status(400).json({ error: 'id required' })
   const link = await getLink(id)
   if (!link) return res.status(404).json({ error: 'not found' })
-  res.json(link)
+  const { blobUrl, ...safe } = link as any
+  res.json(safe)
 }

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -1,7 +1,14 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getUserFromRequest } from '../../lib/auth'
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  const user = getUserFromRequest(req as any)
+  if (!user) {
+    res.writeHead(302, { Location: '/login' })
+    res.end()
+    return
+  }
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
   res.status(200).send(`<!doctype html>
-<html><head><title>API</title></head><body><h1>Batch API</h1><p>Authenticate with <strong>Authorization: Bearer &lt;API Key&gt;</strong>. Find your key on the <a href="/dashboard">Dashboard</a>.</p><p>POST an array of jobs. Each job must include <strong>filename</strong> and <strong>fileUrl</strong>, and may include <strong>lender</strong> and <strong>expiresAt</strong> (epoch ms).</p></body></html>`);
+<html><head><title>API</title></head><body><h1>Batch API</h1><p>Authenticate with <strong>Authorization: Bearer &lt;API Key&gt;</strong>. Find your key on the <a href="/dashboard">Dashboard</a>.</p><p>POST an array of jobs. Each job must include <strong>filename</strong> and <strong>fileUrl</strong>, and may include <strong>lender</strong> and <strong>expiresAt</strong> (epoch ms).</p></body></html>`)
 }

--- a/pages/api/stream.ts
+++ b/pages/api/stream.ts
@@ -15,6 +15,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // NOTE: Vercel Blob private URLs require Authorization; @vercel/blob sdk's "get" isn't available here,
   // so we proxy the stored URL directly if it is public. For private, Vercel handles auth in URL.
   const url = link.blobUrl
+  res.setHeader('Cache-Control', 'no-store')
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  res.setHeader('Referrer-Policy', 'no-referrer')
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow')
   res.setHeader('Content-Type', 'application/pdf')
   https.get(url, r => {
     r.pipe(res)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,5 @@
 import Layout from '../components/Layout'
 import Link from 'next/link'
-import type { GetServerSideProps } from 'next'
-import { getUserFromRequest } from '../lib/auth'
 
 export default function Landing() {
   return (
@@ -11,7 +9,7 @@ export default function Landing() {
         <p className="text-gray-600 mb-6">
           BackdoorDox helps merchant cash advance ISOs protect deal files by stamping every page and tracking every view.
         </p>
-        <Link href="/login" className="btn btn-primary">Log in or Sign up</Link>
+        <Link href="/login?mode=signup" className="btn btn-primary">Get Started</Link>
       </section>
       <div className="grid md:grid-cols-3 gap-4 mt-10">
         <div className="card">
@@ -29,12 +27,4 @@ export default function Landing() {
       </div>
     </Layout>
   )
-}
-
-export const getServerSideProps: GetServerSideProps = async ({ req }) => {
-  const user = getUserFromRequest(req as any)
-  if (!user) {
-    return { redirect: { destination: '/login', permanent: false } }
-  }
-  return { props: {} }
 }

--- a/pages/view/[id].tsx
+++ b/pages/view/[id].tsx
@@ -2,6 +2,7 @@
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import useDeviceFingerprint from '../../components/DeviceFingerprint'
+import type { GetServerSideProps } from 'next'
 
 const FREE_DOMAINS = ['gmail.com','yahoo.com','hotmail.com','outlook.com','aol.com','icloud.com','proton.me','protonmail.com','pm.me','zoho.com','gmx.com']
 
@@ -80,4 +81,12 @@ export default function ViewerGate() {
       </div>
     </div>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.setHeader('Cache-Control', 'no-store')
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  res.setHeader('Referrer-Policy', 'no-referrer')
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow')
+  return { props: {} }
 }


### PR DESCRIPTION
## Summary
- Make marketing home page public and adjust navigation based on auth state
- Add email confirmation tokens, resend API, and production-ready SMTP handling
- Support generating copyable secure links in watermark tool with stricter viewer headers

## Testing
- `npm run lint` *(fails: prompts for Next.js ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0f5abdc8332bb58eab236b8d0df