### PR TITLE
Enable public landing page, email confirmation, and secure link generation

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,13 +1,27 @@
 
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { pathname } = useRouter()
-  const Tab = ({ href, children }: { href: string, children: React.ReactNode }) => (
-    <Link href={href} className={`btn ${pathname===href ? 'bg-gray-900 text-white' : 'btn-outline'} `}>{children}</Link>
+  const [user, setUser] = useState<{ email: string } | null>(null)
+
+  useEffect(() => {
+    fetch('/api/me')
+      .then(r => (r.ok ? r.json() : null))
+      .then(setUser)
+      .catch(() => setUser(null))
+  }, [])
+
+  const Tab = ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <Link href={href} className={`btn ${pathname === href ? 'bg-gray-900 text-white' : 'btn-outline'} `}>{children}</Link>
   )
+
+  const logout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST' })
+    window.location.href = '/'
+  }
 
   return (
     <div>
@@ -15,15 +29,24 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <div className="container py-4 flex items-center gap-4">
           <Link href="/" className="text-xl font-semibold">BackdoorDox</Link>
           <nav className="flex items-center gap-2 flex-1">
-            <Tab href="/dashboard">Dashboard</Tab>
-            <Tab href="/watermark">Watermark</Tab>
-            <Tab href="/activity">Activity</Tab>
-            <Tab href="/api">API</Tab>
-            <Tab href="/payment">Payment</Tab>
+            {user ? (
+              <>
+                <Tab href="/dashboard">Dashboard</Tab>
+                <Tab href="/watermark">Watermark</Tab>
+                <Tab href="/activity">Activity</Tab>
+                <Tab href="/api">API</Tab>
+                <Tab href="/payment">Payment</Tab>
+              </>
+            ) : (
+              <Tab href="/">Home</Tab>
+            )}
           </nav>
           <div className="flex items-center gap-2">
-            <Link href="/login" className="btn btn-outline">Login</Link>
-            <Link href="/login?mode=signup" className="btn btn-primary">Sign up</Link>
+            {user ? (
+              <button onClick={logout} className="btn btn-outline">Logout</button>
+            ) : (
+              <Link href="/login" className="btn btn-outline">Login</Link>
+            )}
           </div>
           <div className="text-sm text-gray-500">MVP</div>
         </div>

--- a/components/WatermarkClient.tsx
+++ b/components/WatermarkClient.tsx
@@ -1,155 +1,364 @@
+import React, { useState, useRef } from 'react'
+import { PDFDocument, StandardFonts, rgb, degrees } from 'pdf-lib'
+import { Upload, X, Trash2, Download, Link as LinkIcon, Copy } from 'lucide-react'
 
-import React, { useState } from 'react'
-import { PDFDocument, rgb, degrees, StandardFonts } from 'pdf-lib'
-import QRCode from 'qrcode'
+type Mode = 'image' | 'text' | 'both'
+type Position = 'diagonal' | 'bottom-right' | 'top-left' | 'center' | 'footer' | 'tiled'
 
-type Props = {
-  ownerId: string
+interface QueueItem {
+  file: File
 }
 
-function toDataURL(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
-    reader.onerror = reject
-    reader.readAsDataURL(file)
+interface Settings {
+  mode: Mode
+  position: Position
+  opacity: number
+  scale: number
+  angle: number
+  margin: number
+  gap: number
+  text: string
+  image?: string
+}
+
+export default function WatermarkClient() {
+  const [queue, setQueue] = useState<QueueItem[]>([])
+  const [settings, setSettings] = useState<Settings>({
+    mode: 'text',
+    position: 'diagonal',
+    opacity: 0.08,
+    scale: 1,
+    angle: 45,
+    margin: 40,
+    gap: 150,
+    text: 'BackdoorDox • Confidential',
   })
-}
+  const [logs, setLogs] = useState<string[]>([])
+  const [linkUrl, setLinkUrl] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
-export default function WatermarkClient({ ownerId }: Props) {
-  const [logo, setLogo] = useState<string | null>(typeof window !== 'undefined' ? localStorage.getItem('bdx_logo') : null)
-  const [qrText, setQrText] = useState<string>('')
-  const [files, setFiles] = useState<FileList | null>(null)
-  const [busy, setBusy] = useState(false)
-  const [resultUrl, setResultUrl] = useState<string>('')
-  const [linkUrl, setLinkUrl] = useState<string>('')
-  const [pdfBytes, setPdfBytes] = useState<Uint8Array | null>(null)
+  const log = (m: string) => setLogs(l => [...l, m])
 
-  const onLogoSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    const dataUrl = await toDataURL(file)
-    setLogo(dataUrl)
-    if (typeof window !== 'undefined') localStorage.setItem('bdx_logo', dataUrl)
+  const addFiles = (list: FileList) => {
+    const items = Array.from(list).filter(f => f.type === 'application/pdf')
+    if (items.length === 0) return
+    setQueue(q => [...q, ...items.map(file => ({ file }))])
   }
 
-  async function process() {
-    if (!files || files.length === 0) return
-    setBusy(true)
-    try {
-      const reader = await files[0].arrayBuffer()
-      const pdfDoc = await PDFDocument.load(reader)
-      const pages = pdfDoc.getPages()
-      const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
-      let pngImage: any = null
-      if (logo) {
-        const bytes = Uint8Array.from(atob(logo.split(',')[1]), c => c.charCodeAt(0))
-        try {
-          pngImage = await pdfDoc.embedPng(bytes)
-        } catch {
-          console.warn('Logo is not PNG, skipping.')
-        }
-      }
-      let qrImage: any = null
-      if (qrText.trim().length > 0) {
-        const qrDataUrl = await QRCode.toDataURL(qrText, { margin: 0, width: 256 })
-        const bytes = Uint8Array.from(atob(qrDataUrl.split(',')[1]), c => c.charCodeAt(0))
-        qrImage = await pdfDoc.embedPng(bytes)
-      }
-      pages.forEach(p => {
-        const { width, height } = p.getSize()
-        const text = 'BackdoorDox • Confidential'
-        const fontSize = Math.min(width, height) / 18
-        p.drawText(text, {
-          x: width / 2 - font.widthOfTextAtSize(text, fontSize) / 2,
-          y: height / 2,
-          size: fontSize,
-          font,
-          color: rgb(0.2, 0.2, 0.2),
-          rotate: degrees(35),
-          opacity: 0.08,
-        })
-        if (qrImage) {
-          const w = 64,
-            h = 64
-          p.drawImage(qrImage, { x: width - w - 24, y: 24, width: w, height: h, opacity: 0.9 })
-        }
-        if (pngImage) {
-          const w = 120
-          const scale = w / pngImage.width
-          const h = pngImage.height * scale
-          p.drawImage(pngImage, { x: 24, y: height - h - 24, width: w, height: h, opacity: 0.75 })
-        }
-      })
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    if (e.dataTransfer.files) addFiles(e.dataTransfer.files)
+  }
 
-      const bytes = await pdfDoc.save()
-      setPdfBytes(bytes)
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) addFiles(e.target.files)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const removeItem = (idx: number) => setQueue(q => q.filter((_, i) => i !== idx))
+  const clearQueue = () => setQueue([])
+
+  const onImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setSettings(s => ({ ...s, image: reader.result as string }))
+    reader.readAsDataURL(file)
+  }
+
+  async function watermarkFile(file: File): Promise<Uint8Array> {
+    log(`Processing ${file.name}`)
+    const array = await file.arrayBuffer()
+    const pdfDoc = await PDFDocument.load(array)
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
+    let embeddedImg: any = null
+    if (settings.mode !== 'text' && settings.image) {
+      const bytes = Uint8Array.from(atob(settings.image.split(',')[1]), c => c.charCodeAt(0))
+      try {
+        embeddedImg = await pdfDoc.embedPng(bytes)
+      } catch {
+        embeddedImg = await pdfDoc.embedJpg(bytes)
+      }
+    }
+    const pages = pdfDoc.getPages()
+    pages.forEach(page => {
+      const { width, height } = page.getSize()
+      const drawAt = (x: number, y: number) => {
+        if (settings.mode !== 'image') {
+          const fontSize = 24 * settings.scale
+          const textWidth = font.widthOfTextAtSize(settings.text, fontSize)
+          page.drawText(settings.text, {
+            x: x - textWidth / 2,
+            y: y - fontSize / 2,
+            size: fontSize,
+            font,
+            color: rgb(0.2, 0.2, 0.2),
+            rotate: degrees(settings.angle),
+            opacity: settings.opacity,
+          })
+        }
+        if (embeddedImg && settings.mode !== 'text') {
+          const scaled = embeddedImg.scale(settings.scale)
+          page.drawImage(embeddedImg, {
+            x: x - scaled.width / 2,
+            y: y - scaled.height / 2,
+            width: scaled.width,
+            height: scaled.height,
+            rotate: degrees(settings.angle),
+            opacity: settings.opacity,
+          })
+        }
+      }
+
+      switch (settings.position) {
+        case 'diagonal':
+          drawAt(width / 2, height / 2)
+          break
+        case 'bottom-right':
+          drawAt(width - settings.margin, settings.margin)
+          break
+        case 'top-left':
+          drawAt(settings.margin, height - settings.margin)
+          break
+        case 'center':
+          drawAt(width / 2, height / 2)
+          break
+        case 'footer':
+          drawAt(width / 2, settings.margin)
+          break
+        case 'tiled':
+          const gap = settings.gap
+          const cols = Math.min(50, Math.ceil((width - settings.margin) / gap))
+          const rows = Math.min(50, Math.ceil((height - settings.margin) / gap))
+          for (let i = 0; i < cols; i++) {
+            for (let j = 0; j < rows; j++) {
+              drawAt(settings.margin + i * gap, settings.margin + j * gap)
+            }
+          }
+          break
+      }
+    })
+    return pdfDoc.save({ useObjectStreams: false, addDefaultPage: false })
+  }
+
+  async function downloadAll() {
+    setLinkUrl('')
+    for (const item of queue) {
+      const bytes = await watermarkFile(item.file)
       const blob = new Blob([bytes], { type: 'application/pdf' })
       const url = URL.createObjectURL(blob)
-      setResultUrl(url)
-      setLinkUrl('')
-    } catch (e: any) {
-      alert('Failed: ' + e.message)
-    } finally {
-      setBusy(false)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = item.file.name.replace(/\.pdf$/i, '') + '_watermarked.pdf'
+      a.click()
+      log(`Downloaded ${a.download}`)
     }
   }
 
   async function generateLink() {
-    if (!pdfBytes || !files) return
-    setBusy(true)
-    try {
-      const form = new FormData()
-      form.append('file', new Blob([pdfBytes], { type: 'application/pdf' }), files[0].name.replace(/\.pdf$/i, '') + '-watermarked.pdf')
-      form.append('ownerId', ownerId)
-      if (qrText) form.append('qr', qrText)
-      const upload = await fetch('/api/upload', { method: 'POST', body: form })
-      if (!upload.ok) throw new Error('Upload failed')
-      const data = await upload.json()
-      setLinkUrl(data.viewerUrl)
-    } catch (e: any) {
-      alert('Failed: ' + e.message)
-    } finally {
-      setBusy(false)
+    if (queue.length === 0) return
+    const bytes = await watermarkFile(queue[0].file)
+    const form = new FormData()
+    form.append(
+      'file',
+      new Blob([bytes], { type: 'application/pdf' }),
+      queue[0].file.name.replace(/\.pdf$/i, '') + '_watermarked.pdf'
+    )
+    const upload = await fetch('/api/upload', { method: 'POST', body: form })
+    if (!upload.ok) {
+      log('Upload failed')
+      return
     }
+    const data = await upload.json()
+    setLinkUrl(data.viewerUrl)
+    log('Secure link generated')
   }
 
   return (
     <div className="space-y-6">
       <div className="card">
-        <h2 className="text-lg font-semibold mb-2">1) Stored Logo</h2>
-        <p className="hint mb-3">Upload your PNG logo once and we’ll store it in your browser for future sessions.</p>
-        <input type="file" accept="image/png" onChange={onLogoSelect} />
-        {logo && <div className="mt-3"><img src={logo} alt="logo" className="w-40 rounded border" /></div>}
+        <h2 className="text-lg font-semibold mb-2">Files</h2>
+        <div
+          onDragOver={e => e.preventDefault()}
+          onDrop={handleDrop}
+          className="border-2 border-dashed rounded p-6 text-center"
+        >
+          <input
+            type="file"
+            multiple
+            accept="application/pdf"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            className="hidden"
+          />
+          <p className="mb-2 text-sm flex flex-col items-center gap-2">
+            <Upload className="w-5 h-5" />
+            Drag & drop PDFs here or
+            <button
+              type="button"
+              className="underline"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              browse
+            </button>
+          </p>
+        </div>
+        {queue.length > 0 && (
+          <>
+            <ul className="mt-4 space-y-2">
+              {queue.map((item, idx) => (
+                <li key={idx} className="flex items-center justify-between bg-gray-50 p-2 rounded">
+                  <span className="text-sm truncate">{item.file.name}</span>
+                  <button onClick={() => removeItem(idx)} className="text-red-500">
+                    <X className="w-4 h-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <button onClick={clearQueue} className="btn btn-outline mt-2 flex items-center gap-2">
+              <Trash2 className="w-4 h-4" /> Clear
+            </button>
+          </>
+        )}
       </div>
 
       <div className="card">
-        <h2 className="text-lg font-semibold mb-2">2) (Optional) QR Code</h2>
-        <p className="hint mb-3">Embed a small QR code on each page (bottom-right). Use it to encode a case ID, link, or lender name.</p>
-        <input className="input" placeholder="optional text to encode" value={qrText} onChange={e=>setQrText(e.target.value)} />
-      </div>
-
-      <div className="card">
-        <h2 className="text-lg font-semibold mb-2">3) Watermark</h2>
-        <p className="hint mb-3">Upload PDF (or try images—we’ll pass them as-is in this MVP).</p>
-        <input type="file" accept="application/pdf" onChange={e=>setFiles(e.target.files)} />
-        <div className="mt-4 flex flex-col gap-3">
-          <div className="flex items-center gap-3">
-            <button disabled={!files || busy} onClick={process} className="btn btn-primary">{busy ? 'Processing…' : 'Watermark'}</button>
-            {resultUrl && <a className="btn btn-outline" href={resultUrl} download>Download Watermarked PDF</a>}
-            {pdfBytes && !linkUrl && <button onClick={generateLink} className="btn btn-outline">Generate Secure Link</button>}
+        <h2 className="text-lg font-semibold mb-2">Settings</h2>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm mb-1">Mode</label>
+            <select
+              className="input"
+              value={settings.mode}
+              onChange={e => setSettings(s => ({ ...s, mode: e.target.value as Mode }))}
+            >
+              <option value="text">Text</option>
+              <option value="image">Image</option>
+              <option value="both">Both</option>
+            </select>
           </div>
-          {linkUrl && (
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <input className="input flex-1" value={linkUrl} readOnly />
-                <button className="btn" onClick={() => navigator.clipboard.writeText(linkUrl)}>Copy Link</button>
-              </div>
-              <div className="hint">Secure link created. Every open will be logged.</div>
+          <div>
+            <label className="block text-sm mb-1">Position</label>
+            <select
+              className="input"
+              value={settings.position}
+              onChange={e => setSettings(s => ({ ...s, position: e.target.value as Position }))}
+            >
+              <option value="diagonal">Diagonal Center</option>
+              <option value="bottom-right">Bottom Right</option>
+              <option value="top-left">Top Left</option>
+              <option value="center">Center</option>
+              <option value="footer">Footer</option>
+              <option value="tiled">Tiled</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Opacity</label>
+            <input
+              type="number"
+              step="0.05"
+              min="0"
+              max="1"
+              className="input"
+              value={settings.opacity}
+              onChange={e => setSettings(s => ({ ...s, opacity: parseFloat(e.target.value) }))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Scale</label>
+            <input
+              type="number"
+              step="0.1"
+              min="0.1"
+              className="input"
+              value={settings.scale}
+              onChange={e => setSettings(s => ({ ...s, scale: parseFloat(e.target.value) }))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Angle</label>
+            <input
+              type="number"
+              className="input"
+              value={settings.angle}
+              onChange={e => setSettings(s => ({ ...s, angle: parseFloat(e.target.value) }))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Margin</label>
+            <input
+              type="number"
+              className="input"
+              value={settings.margin}
+              onChange={e => setSettings(s => ({ ...s, margin: parseFloat(e.target.value) }))}
+            />
+          </div>
+          {settings.position === 'tiled' && (
+            <div>
+              <label className="block text-sm mb-1">Gap</label>
+              <input
+                type="number"
+                className="input"
+                value={settings.gap}
+                onChange={e => setSettings(s => ({ ...s, gap: parseFloat(e.target.value) }))}
+              />
+            </div>
+          )}
+          {settings.mode !== 'image' && (
+            <div className="col-span-2">
+              <label className="block text-sm mb-1">Text</label>
+              <input
+                className="input"
+                value={settings.text}
+                onChange={e => setSettings(s => ({ ...s, text: e.target.value }))}
+              />
+            </div>
+          )}
+          {settings.mode !== 'text' && (
+            <div className="col-span-2">
+              <label className="block text-sm mb-1">Watermark Image</label>
+              <input type="file" accept="image/*" onChange={onImageChange} />
+              {settings.image && <img src={settings.image} alt="watermark" className="mt-2 w-32 border rounded" />}
             </div>
           )}
         </div>
       </div>
+
+      <div className="card">
+        <div className="flex flex-wrap gap-3">
+          <button
+            className="btn btn-primary flex items-center gap-2"
+            disabled={queue.length === 0}
+            onClick={downloadAll}
+          >
+            <Download className="w-4 h-4" /> Download Watermarked PDF(s)
+          </button>
+          <button
+            className="btn btn-outline flex items-center gap-2"
+            disabled={queue.length === 0}
+            onClick={generateLink}
+          >
+            <LinkIcon className="w-4 h-4" /> Generate Secure Link
+          </button>
+        </div>
+        {linkUrl && (
+          <div className="mt-4 space-y-1">
+            <div className="flex gap-2">
+              <input className="input flex-1" value={linkUrl} readOnly />
+              <button className="btn" onClick={() => navigator.clipboard.writeText(linkUrl)}>
+                <Copy className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="hint">Secure link created. Every open will be logged.</div>
+          </div>
+        )}
+      </div>
+
+      <div className="card">
+        <h2 className="text-lg font-semibold mb-2">Logs</h2>
+        <pre className="bg-gray-100 p-2 rounded h-40 overflow-auto text-xs whitespace-pre-wrap">{logs.join('\n')}</pre>
+      </div>
     </div>
   )
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vercel/kv": "^1.0.1",
         "bcryptjs": "^3.0.2",
         "jsonwebtoken": "^9.0.2",
+        "lucide-react": "^0.540.0",
         "next": "14.2.5",
         "nodemailer": "^6.9.11",
         "pdf-lib": "1.17.1",
@@ -2866,6 +2867,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.540.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.540.0.tgz",
+      "integrity": "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@vercel/kv": "^1.0.1",
     "bcryptjs": "^3.0.2",
     "jsonwebtoken": "^9.0.2",
+    "lucide-react": "^0.540.0",
     "next": "14.2.5",
     "nodemailer": "^6.9.11",
     "pdf-lib": "1.17.1",

--- a/pages/api/auth/confirm.ts
+++ b/pages/api/auth/confirm.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { kv } from '@vercel/kv'
+import { requireEnv } from '../../../lib/env'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end()
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
+  const token = req.query.token as string
+  if (!token) return res.status(400).end('token required')
+  const email = await kv.get<string>(`confirm:${token}`)
+  if (!email) {
+    res.status(400).end('Invalid or expired token')
+    return
+  }
+  await kv.hset(`user:${email}`, { confirmedAt: new Date().toISOString() } as any)
+  await kv.del(`confirm:${token}`)
+  await kv.del(`confirm-email:${email}`)
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
+  res.end('<p>Email confirmed. You can now <a href="/login">log in</a>.</p>')
+}

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { authenticate, createSession } from '../../../lib/auth'
 import { requireEnv } from '../../../lib/env'
+import { kv } from '@vercel/kv'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -10,10 +11,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN', 'JWT_SECRET'])) return
   const { email, password } = req.body
   const user = await authenticate(email, password)
-  if (user) {
+  if (!user) {
+    res.status(401).json({ error: 'Invalid credentials' })
+    return
+  }
+  if (user.confirmedAt) {
     createSession(res, user)
     res.status(200).json({ ok: true })
-  } else {
-    res.status(401).json({ error: 'Invalid credentials' })
+    return
   }
+  const pending = await kv.get(`confirm-email:${user.email}`)
+  if (pending) {
+    res.status(403).json({ error: 'UNCONFIRMED' })
+    return
+  }
+  createSession(res, user)
+  res.status(200).json({ ok: true })
 }

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  res.setHeader('Set-Cookie', 'bdx_session=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0')
+  res.status(200).json({ ok: true })
+}

--- a/pages/api/auth/resend-confirmation.ts
+++ b/pages/api/auth/resend-confirmation.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { kv } from '@vercel/kv'
+import { requireEnv } from '../../../lib/env'
+import { getUser, sendConfirmationEmail } from '../../../lib/auth'
+import crypto from 'crypto'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
+  const { email } = req.body || {}
+  if (!email) return res.status(200).json({ ok: true })
+  const ip = (req.headers['x-forwarded-for'] as string || '').split(',')[0] || req.socket.remoteAddress || 'unknown'
+  const key = `resend:${ip}:${email}`
+  const count = await kv.incr(key)
+  if (count === 1) await kv.expire(key, 3600)
+  if (count > 3) return res.status(200).json({ ok: true })
+  const user = await getUser(email)
+  if (user && !user.confirmedAt) {
+    const token = crypto.randomBytes(32).toString('hex')
+    await kv.set(`confirm:${token}`, user.email, { ex: 60 * 60 * 24 })
+    await kv.set(`confirm-email:${user.email}`, token, { ex: 60 * 60 * 24 })
+    await sendConfirmationEmail(user.email, token)
+  }
+  res.status(200).json({ ok: true })
+}

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { registerUser, createSession } from '../../../lib/auth'
+import { registerUser, sendConfirmationEmail } from '../../../lib/auth'
 import { requireEnv } from '../../../lib/env'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -7,12 +7,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(405).end()
     return
   }
-  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN', 'JWT_SECRET'])) return
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
   const { email, password } = req.body
   try {
-    const user = await registerUser(email, password)
-    createSession(res, user)
-    res.status(200).json({ ok: true })
+    const { token } = await registerUser(email, password)
+    const url = await sendConfirmationEmail(email, token)
+    const { EMAIL_SERVER_HOST, EMAIL_SERVER_PORT, EMAIL_SERVER_USER, EMAIL_SERVER_PASS, EMAIL_FROM } =
+      process.env as Record<string, string | undefined>
+    const hasSMTP = EMAIL_SERVER_HOST && EMAIL_SERVER_PORT && EMAIL_SERVER_USER && EMAIL_SERVER_PASS && EMAIL_FROM
+    const body: any = { ok: true }
+    if (!hasSMTP && process.env.NODE_ENV !== 'production') body.devLink = url
+    res.status(200).json(body)
   } catch (err: any) {
     res.status(400).json({ error: err.message || 'error' })
   }

--- a/pages/api/get-link.ts
+++ b/pages/api/get-link.ts
@@ -9,5 +9,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!id) return res.status(400).json({ error: 'id required' })
   const link = await getLink(id)
   if (!link) return res.status(404).json({ error: 'not found' })
-  res.json(link)
+  const { blobUrl, ...safe } = link as any
+  res.json(safe)
 }

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -1,7 +1,14 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getUserFromRequest } from '../../lib/auth'
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  const user = getUserFromRequest(req as any)
+  if (!user) {
+    res.writeHead(302, { Location: '/login' })
+    res.end()
+    return
+  }
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
   res.status(200).send(`<!doctype html>
-<html><head><title>API</title></head><body><h1>Batch API</h1><p>Authenticate with <strong>Authorization: Bearer &lt;API Key&gt;</strong>. Find your key on the <a href="/dashboard">Dashboard</a>.</p><p>POST an array of jobs. Each job must include <strong>filename</strong> and <strong>fileUrl</strong>, and may include <strong>lender</strong> and <strong>expiresAt</strong> (epoch ms).</p></body></html>`);
+<html><head><title>API</title></head><body><h1>Batch API</h1><p>Authenticate with <strong>Authorization: Bearer &lt;API Key&gt;</strong>. Find your key on the <a href="/dashboard">Dashboard</a>.</p><p>POST an array of jobs. Each job must include <strong>filename</strong> and <strong>fileUrl</strong>, and may include <strong>lender</strong> and <strong>expiresAt</strong> (epoch ms).</p></body></html>`)
 }

--- a/pages/api/stream.ts
+++ b/pages/api/stream.ts
@@ -15,6 +15,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // NOTE: Vercel Blob private URLs require Authorization; @vercel/blob sdk's "get" isn't available here,
   // so we proxy the stored URL directly if it is public. For private, Vercel handles auth in URL.
   const url = link.blobUrl
+  res.setHeader('Cache-Control', 'no-store')
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  res.setHeader('Referrer-Policy', 'no-referrer')
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow')
   res.setHeader('Content-Type', 'application/pdf')
   https.get(url, r => {
     r.pipe(res)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,5 @@
 import Layout from '../components/Layout'
 import Link from 'next/link'
-import type { GetServerSideProps } from 'next'
-import { getUserFromRequest } from '../lib/auth'
 
 export default function Landing() {
   return (
@@ -11,7 +9,7 @@ export default function Landing() {
         <p className="text-gray-600 mb-6">
           BackdoorDox helps merchant cash advance ISOs protect deal files by stamping every page and tracking every view.
         </p>
-        <Link href="/login" className="btn btn-primary">Log in or Sign up</Link>
+        <Link href="/login?mode=signup" className="btn btn-primary">Get Started</Link>
       </section>
       <div className="grid md:grid-cols-3 gap-4 mt-10">
         <div className="card">
@@ -29,12 +27,4 @@ export default function Landing() {
       </div>
     </Layout>
   )
-}
-
-export const getServerSideProps: GetServerSideProps = async ({ req }) => {
-  const user = getUserFromRequest(req as any)
-  if (!user) {
-    return { redirect: { destination: '/login', permanent: false } }
-  }
-  return { props: {} }
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -8,6 +8,10 @@ export default function Login() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+  const [status, setStatus] = useState('')
+  const [resendMsg, setResendMsg] = useState('')
+  const [unconfirmed, setUnconfirmed] = useState(false)
+  const [devLink, setDevLink] = useState('')
 
   useEffect(() => {
     if (router.query.mode === 'signup') setMode('signup')
@@ -16,16 +20,47 @@ export default function Login() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+    setStatus('')
+    setResendMsg('')
+    setDevLink('')
     const res = await fetch(`/api/auth/${mode}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })
     })
+    const data = await res.json().catch(() => ({}))
     if (res.ok) {
-      router.push('/dashboard')
+      if (mode === 'login') {
+        router.push('/dashboard')
+      } else {
+        setStatus('Check your email to confirm your account')
+        setMode('login')
+        setDevLink(data.devLink || '')
+        setUnconfirmed(false)
+      }
     } else {
-      const data = await res.json()
-      setError(data.error || 'Error')
+      if (res.status === 403 && data.error === 'UNCONFIRMED') {
+        setUnconfirmed(true)
+        setError('Please confirm your email.')
+      } else {
+        setUnconfirmed(false)
+        setError(data.error || 'Error')
+      }
+    }
+  }
+
+  const resend = async () => {
+    setResendMsg('')
+    const res = await fetch('/api/auth/resend-confirmation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    })
+    const data = await res.json().catch(() => ({}))
+    if (res.ok && !data.error) {
+      setResendMsg('If an account exists, we sent an email.')
+    } else {
+      setResendMsg(data.error || 'Unable to resend')
     }
   }
 
@@ -39,7 +74,24 @@ export default function Login() {
         <form onSubmit={handleSubmit} className="space-y-4">
           <input type="email" required placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} className="input w-full" />
           <input type="password" required placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} className="input w-full" />
-          {error && <p className="text-red-500 text-sm">{error}</p>}
+          {status && (
+            <p className="text-green-600 text-sm">
+              {status}
+              <button type="button" onClick={resend} className="underline ml-1">Resend confirmation</button>
+              {devLink && (
+                <a href={devLink} className="underline ml-1">Confirm now</a>
+              )}
+            </p>
+          )}
+          {error && (
+            <p className="text-red-500 text-sm">
+              {error}
+              {unconfirmed && (
+                <button type="button" onClick={resend} className="underline ml-1">Resend link</button>
+              )}
+            </p>
+          )}
+          {resendMsg && <p className="text-sm text-green-600">{resendMsg}</p>}
           <button type="submit" className="btn btn-primary w-full">{mode==='login' ? 'Log in' : 'Create account'}</button>
         </form>
       </div>

--- a/pages/view/[id].tsx
+++ b/pages/view/[id].tsx
@@ -2,6 +2,7 @@
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import useDeviceFingerprint from '../../components/DeviceFingerprint'
+import type { GetServerSideProps } from 'next'
 
 const FREE_DOMAINS = ['gmail.com','yahoo.com','hotmail.com','outlook.com','aol.com','icloud.com','proton.me','protonmail.com','pm.me','zoho.com','gmx.com']
 
@@ -80,4 +81,12 @@ export default function ViewerGate() {
       </div>
     </div>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.setHeader('Cache-Control', 'no-store')
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  res.setHeader('Referrer-Policy', 'no-referrer')
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow')
+  return { props: {} }
 }

--- a/pages/watermark.tsx
+++ b/pages/watermark.tsx
@@ -1,27 +1,16 @@
 
 import Layout from '../components/Layout'
 import dynamic from 'next/dynamic'
-import { useEffect, useState } from 'react'
 import type { GetServerSideProps } from 'next'
 import { getUserFromRequest } from '../lib/auth'
 
 const WatermarkClient = dynamic(() => import('../components/WatermarkClient'), { ssr: false })
 
-function getOwnerId() {
-  if (typeof window === 'undefined') return 'anon'
-  const key = 'bdx_owner'
-  let id = localStorage.getItem(key)
-  if (!id) { id = Math.random().toString(36).slice(2); localStorage.setItem(key, id) }
-  return id
-}
-
 export default function Page() {
-  const [ownerId, setOwnerId] = useState('')
-  useEffect(()=>{ setOwnerId(getOwnerId()) }, [])
   return (
     <Layout>
       <h1 className="text-2xl font-semibold">Watermark Console</h1>
-      <WatermarkClient ownerId={ownerId} />
+      <WatermarkClient />
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- Remove null confirmation fields, store one-time tokens per email, and send confirmations via configurable SMTP vars
- Grandfather legacy accounts, block only pending confirmations, and expose a dev confirmation link when SMTP is absent
- Surface resend links only after unconfirmed login attempts and keep secure-link messaging alongside watermark downloads

## Testing
- `npm run lint` *(fails: prompts for Next.js ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0f5abdc8332bb58eab236b8d0df