### PR TITLE
Add dev fallback for secure link uploads and clarify errors

### DIFF
--- a/components/WatermarkClient.tsx
+++ b/components/WatermarkClient.tsx
@@ -166,7 +166,14 @@ export default function WatermarkClient() {
     )
     const upload = await fetch('/api/upload', { method: 'POST', body: form })
     if (!upload.ok) {
-      log('Upload failed')
+      let message = 'Upload failed'
+      try {
+        const err = await upload.json()
+        message = err.error || message
+      } catch {
+        // ignore
+      }
+      log(message)
       return
     }
     const data = await upload.json()

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -85,12 +85,38 @@ const raws = (await kv.zrange(key, 0, limit - 1, { rev: true })) as string[];
 export async function deleteLink(link: LinkMeta) {
   await kv.del(`link:${link.id}`)
   await kv.del(`link:${link.id}:events`)
-  await del(link.blobUrl)
+  if (link.blobUrl.startsWith('file://')) {
+    const { unlink } = await import('fs/promises')
+    try {
+      await unlink(new URL(link.blobUrl))
+    } catch {
+      // ignore
+    }
+  } else {
+    await del(link.blobUrl)
+  }
   await kv.zrem(`links:${link.ownerId}`, link.id)
 }
 
 export type UploadResult = { fileId: string, filename: string, url: string }
 export async function savePDF(ownerId: string, filename: string, buf: Buffer): Promise<UploadResult> {
+  const token = process.env.BLOB_READ_WRITE_TOKEN
+  const bucket = process.env.BLOB_BUCKET_URL
+
+  if (!token || !bucket) {
+    if (process.env.NODE_ENV === 'development') {
+      const { mkdir, writeFile } = await import('fs/promises')
+      const path = await import('path')
+      const dir = '/tmp/uploads'
+      await mkdir(dir, { recursive: true })
+      const filePath = path.join(dir, `${Date.now()}-${filename}`)
+      await writeFile(filePath, buf)
+      return { fileId: filePath, filename, url: `file://${filePath}` }
+    }
+    const missing = !token ? 'BLOB_READ_WRITE_TOKEN' : 'BLOB_BUCKET_URL'
+    throw new Error(`Blob upload failed: missing ${missing}`)
+  }
+
   // Public for MVP demo; switch to 'private' + signed URLs later
   const putRes = await put(`pdfs/${ownerId}/${Date.now()}-${filename}`, buf, {
     contentType: 'application/pdf',

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -46,7 +46,7 @@ function parseForm(req: NextApiRequest): Promise<{buffer: Buffer, filename: stri
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end()
-  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN', 'BLOB_READ_WRITE_TOKEN', 'JWT_SECRET', 'NEXT_PUBLIC_APP_URL'])) return
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN', 'JWT_SECRET', 'NEXT_PUBLIC_APP_URL'])) return
   const user = getUserFromRequest(req as any)
   if (!user) return res.status(401).json({ ok: false, error: 'Unauthorized' })
   try {


### PR DESCRIPTION
## Summary
- Log detailed upload errors in `WatermarkClient`
- Save PDFs to `/tmp` when blob env vars missing and stream `file://` links in dev
- Relax blob env requirements in upload API for local testing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6fcf36a0c833283373408f9104cf7