### PR TITLE
feat: secure tokenized PDF streaming

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -22,7 +22,11 @@ export type AccessEvent = {
   country?: string
   ua?: string
   email?: string
-  fingerprint?: string
+  fpHash?: string
+  tz?: string
+  screen?: string
+  succeeded?: boolean
+  token?: boolean
 }
 
 const LinkSchema = z.object({

--- a/pages/activity.tsx
+++ b/pages/activity.tsx
@@ -41,6 +41,7 @@ export default function Activity() {
               <th className="py-2 pr-4">Events</th>
               <th className="py-2 pr-4">Created</th>
               <th className="py-2 pr-4">Risk</th>
+              <th className="py-2 pr-4">Last View</th>
               <th className="py-2 pr-4">Link</th>
             </tr>
           </thead>
@@ -60,6 +61,17 @@ export default function Activity() {
                       </span>
                     )}
                   </div>
+                </td>
+                <td className="py-2 pr-4 text-xs">
+                  {l.last ? (
+                    <span>
+                      {l.last.token && <span title="via token">✓ token </span>}
+                      {l.last.ip || '-'}
+                      {l.last.fpHash && ` (${l.last.fpHash.slice(0, 12)})`}
+                    </span>
+                  ) : (
+                    '-'
+                  )}
                 </td>
                 <td className="py-2 pr-4">
                   <div className="flex gap-2">

--- a/pages/api/links.ts
+++ b/pages/api/links.ts
@@ -41,7 +41,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     links.map(async l => {
       const events = await getAccesses(l.id, 200)
       const { score, reasons } = computeRisk(events)
-      return { ...l, risk: score, flags: reasons }
+      return { ...l, risk: score, flags: reasons, last: events[0] || null }
     })
   )
   res.json({ links: withRisk })

--- a/pages/api/log-access.ts
+++ b/pages/api/log-access.ts
@@ -6,11 +6,29 @@ import { requireEnv } from '../../lib/env'
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end()
   if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
-  const { linkId, email, fingerprint } = req.body || {}
-  if (!linkId) return res.status(400).json({ ok:false, error:'linkId required' })
-  const ip = (req.headers['x-forwarded-for'] as string || '').split(',')[0] || req.socket.remoteAddress || undefined
-  const country = (req.headers['x-vercel-ip-country'] as string) || (req.headers['cf-ipcountry'] as string) || undefined
-  const ua = req.headers['user-agent'] as string | undefined
-  await logAccess(linkId, { id: Math.random().toString(36).slice(2), at: Date.now(), ip, country, ua, email, fingerprint })
-  res.json({ ok:true })
+  const { linkId, email, fpHash, userAgent, tz, screen, succeeded, token } = req.body || {}
+  if (!linkId) return res.status(400).json({ ok: false, error: 'linkId required' })
+  const ip =
+    (req.headers['x-forwarded-for'] as string || '').split(',')[0] ||
+    req.socket.remoteAddress ||
+    undefined
+  const country =
+    (req.headers['x-vercel-ip-country'] as string) ||
+    (req.headers['cf-ipcountry'] as string) ||
+    undefined
+  const ua = userAgent || (req.headers['user-agent'] as string | undefined)
+  await logAccess(linkId, {
+    id: Math.random().toString(36).slice(2),
+    at: Date.now(),
+    ip,
+    country,
+    ua,
+    email,
+    fpHash,
+    tz,
+    screen,
+    succeeded,
+    token,
+  })
+  res.json({ ok: true })
 }

--- a/pages/api/stream/token.ts
+++ b/pages/api/stream/token.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import crypto from 'crypto'
+import { kv } from '@vercel/kv'
+import { requireEnv } from '../../../lib/env'
+import { sanitizeForKv } from '../../../lib/kv'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  if (!requireEnv(res, ['KV_REST_API_URL', 'KV_REST_API_TOKEN'])) return
+  const { id, email, lender, fpHash, ua, tz, screen } = req.body || {}
+  if (!id || !email) return res.status(400).json({ ok: false, error: 'id and email required' })
+  const st = crypto.randomBytes(16).toString('base64url')
+  const ip = (req.headers['x-forwarded-for'] as string || '').split(',')[0] || req.socket.remoteAddress
+  const now = Date.now()
+  const token = {
+    id,
+    email,
+    lender,
+    ip,
+    fpHash,
+    ua,
+    tz,
+    screen,
+    createdAt: now,
+    expiresAt: now + 10 * 60 * 1000,
+    consumed: false,
+  }
+  const key = `st:${st}`
+  await kv.hset(key, sanitizeForKv(token))
+  await kv.expire(key, 600)
+  res.json({ ok: true, st })
+}


### PR DESCRIPTION
## Summary
- add short-lived stream tokens and enforce them in `/api/stream/[id]`
- gate viewer with device fingerprint, tokenized iframe, and diagnostics panel
- show last access ip/fingerprint/token in activity dashboard

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: interactive ESLint prompt)*
- `npx tsc --noEmit` *(fails: Cannot find module 'lucide-react')*

------
https://chatgpt.com/codex/tasks/task_e_68a78a89dd38833296fc6f2b0e1c8c48