### PR TITLE
Replace X-Frame-Options with CSP frame-ancestors policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,12 @@ const nextConfig = {
     {
       source: "/view/:path*",
       headers: [
-        { key: "X-Frame-Options", value: "SAMEORIGIN" },
         { key: "Referrer-Policy", value: "no-referrer" },
+        {
+          key: "Content-Security-Policy",
+          value:
+            "frame-ancestors https://backdoordox-v2.vercel.app https://*.backdoordox-v2.vercel.app;",
+        },
       ],
     },
   ]),

--- a/pages/api/stream/[id].ts
+++ b/pages/api/stream/[id].ts
@@ -16,7 +16,6 @@ function buildHeaders(filename: string) {
   const name = safe.endsWith('.pdf') ? safe : safe + '.pdf'
   return {
     'Cache-Control': 'no-store',
-    'X-Frame-Options': 'SAMEORIGIN',
     'Referrer-Policy': 'no-referrer',
     'X-Robots-Tag': 'noindex, nofollow',
     'Content-Type': 'application/pdf',
@@ -24,6 +23,8 @@ function buildHeaders(filename: string) {
     'Accept-Ranges': 'bytes',
     'Cross-Origin-Resource-Policy': 'same-origin',
     'Content-Encoding': 'identity',
+    'Content-Security-Policy':
+      'frame-ancestors https://backdoordox-v2.vercel.app https://*.backdoordox-v2.vercel.app;',
   } as Record<string, string>
 }
 

--- a/pages/api/stream/meta.ts
+++ b/pages/api/stream/meta.ts
@@ -21,7 +21,6 @@ function buildHeaders(filename: string) {
   const name = safe.endsWith('.pdf') ? safe : safe + '.pdf'
   return {
     'Cache-Control': 'no-store',
-    'X-Frame-Options': 'SAMEORIGIN',
     'Referrer-Policy': 'no-referrer',
     'X-Robots-Tag': 'noindex, nofollow',
     'Content-Type': 'application/pdf',
@@ -29,6 +28,8 @@ function buildHeaders(filename: string) {
     'Accept-Ranges': 'bytes',
     'Cross-Origin-Resource-Policy': 'same-origin',
     'Content-Encoding': 'identity',
+    'Content-Security-Policy':
+      'frame-ancestors https://backdoordox-v2.vercel.app https://*.backdoordox-v2.vercel.app;',
   } as Record<string, string>
 }
 

--- a/pages/view/[id].tsx
+++ b/pages/view/[id].tsx
@@ -321,9 +321,11 @@ export default function ViewerGate() {
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   res.setHeader('Cache-Control', 'no-store')
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
   res.setHeader('Referrer-Policy', 'no-referrer')
   res.setHeader('X-Robots-Tag', 'noindex, nofollow')
-  res.setHeader('Content-Security-Policy', "frame-ancestors 'self'")
+  res.setHeader(
+    'Content-Security-Policy',
+    'frame-ancestors https://backdoordox-v2.vercel.app https://*.backdoordox-v2.vercel.app;'
+  )
   return { props: {} }
 }


### PR DESCRIPTION
## Summary
- remove legacy X-Frame-Options headers
- add frame-ancestors CSP allowing backdoordox-v2.vercel.app and subdomains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8734bf3e083329a3d97bfb000b670